### PR TITLE
update to Realm 10.24.2

### DIFF
--- a/local_pod_repo/objcTox/Podfile
+++ b/local_pod_repo/objcTox/Podfile
@@ -6,7 +6,7 @@ inhibit_all_warnings!
 def common_pods
     pod "toxcore", :git => 'https://github.com/Zoxcore/toxcore.git', :commit => '5cf8c66a8fc3f2ab0708a15e3d77ba9e77f48a81'
     pod 'CocoaLumberjack', '~> 1.9.2'
-    pod 'Realm', '10.24.0'
+    pod 'Realm', '10.24.2'
     pod 'TPCircularBuffer', '~> 0.0.1'
 end
 

--- a/local_pod_repo/objcTox/objcTox.podspec
+++ b/local_pod_repo/objcTox/objcTox.podspec
@@ -29,7 +29,7 @@ Pod::Spec.new do |s|
   s.dependency 'toxcore', '~> 0.2.12'
   s.dependency 'TPCircularBuffer', '~> 0.0.1'
   s.dependency 'CocoaLumberjack', '1.9.2'
-  s.dependency 'Realm', '10.24.0'
+  s.dependency 'Realm', '10.24.2'
 
   s.resource_bundle = {
       'objcTox' => 'Classes/Public/Manager/nodes.json'


### PR DESCRIPTION
Fixed in Realm v10.24.2:

Application would sometimes crash with exceptions like 'KeyNotFound' or assertion "has_refs()". Other issues indicating file corruption may also be fixed by this. The one mentioned here is the one that lead to solving the problem.
(https://github.com/realm/realm-core/issues/5283, since v5.0.0)